### PR TITLE
Clang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Oak is a lightweight and robust logging library for C++23, designed to
 simplify logging in modern C++ applications. As a single-header library,
 it requires no additional dependencies—simply include it in your project
-and start logging immediately.
+and start logging immediately. Works on both clang and gcc.
 
 Built with modern C++ practices, Oak leverages advanced language
 features to offer high performance and flexibility. Key features include:
@@ -18,7 +18,7 @@ features to offer high performance and flexibility. Key features include:
                  tailor the logging experience to your specific requirements.
 
 This code was originally forked from the logger of [Brenta Engine](https://github.com/San7o/Brenta-Engine)
-in order to develop it indipendently from the engine.
+in order to develop it independently from the engine.
 
 ## Features
 
@@ -94,7 +94,7 @@ You can also serialize the log adding the flag `oak::flags::json`:
 ```c++
 auto file = oak::set_file("/tmp/my-log");
 if (!file.has_value())
-    oak::error("Error opening setting file: {}", file.error());
+    oak::error("Error setting file: {}", file.error());
 ```
 The library uses `std::expected` to handle errors.
 

--- a/docs/docs.doxygen
+++ b/docs/docs.doxygen
@@ -13,7 +13,7 @@
 /// Oak is a lightweight and robust logging library for C++23, designed to
 /// simplify logging in modern C++ applications. As a single-header library,
 /// it requires no additional dependencies—simply include it in your project
-/// and start logging immediately.
+/// and start logging immediately. Works on both clang anc gcc.
 /// 
 /// Built with modern C++ practices, Oak leverages advanced language
 /// features to offer high performance and flexibility. Key features include:

--- a/tests/oak_tests.cpp
+++ b/tests/oak_tests.cpp
@@ -177,7 +177,7 @@ void test_unix_socket()
     ssize_t n = read(accepted_sock, buf, 1024);
     ASSERT(n > 0);
     ASSERT_EQ(n, 28);
-    ASSERT_EQ(std::string(buf, n), "[ level=info ] hello socket\n");
+    ASSERT_EQ(std::string(buf, (unsigned long) n), "[ level=info ] hello socket\n");
 
     t.join();
     oak::close_socket();
@@ -211,7 +211,7 @@ void test_net_socket()
     ssize_t n = read(accepted_sock, buf, 1024);
     ASSERT(n > 0);
     ASSERT_EQ(n, 28);
-    ASSERT_EQ(std::string(buf, n), "[ level=info ] hello socket\n");
+    ASSERT_EQ(std::string(buf, (unsigned long) n), "[ level=info ] hello socket\n");
 
     t.join();
     oak::close_socket();

--- a/tests/test.hpp
+++ b/tests/test.hpp
@@ -13,7 +13,8 @@
     num_assertions++;                                                          \
     if ((x) != (y))                                                            \
     {                                                                          \
-        std::print("Line {} in file {}: Assertion failed: {} != {}\n",         \
-                   __LINE__, __FILE__, x, y);                                  \
+        std::cout << "Line " << __LINE__ << " in file " << __FILE__            \
+                  << ": Assertion failed: " << std::format("{}", x)            \
+                  << " != " << std::format("{}", y) << "\n";                   \
         errors++;                                                              \
     }


### PR DESCRIPTION
## Description

Removed clang warnings, closes #2 
Apparently gcc allows the use of `std::format` in non constexpr function, while clang doesn't